### PR TITLE
Remove "211_USGS" from Quabbin Rating dropdown list

### DIFF
--- a/mod_ratings.R
+++ b/mod_ratings.R
@@ -129,7 +129,7 @@ RATINGS <- function(input, output, session, df_ratings, df_discharges) {
   })
   }else{
     site_choices <- reactive({
-      c(df_discharges %>% .$Location) %>%
+      c((df_discharges %>% filter(!Location %in% c("211_USGS"))) %>% .$Location) %>%
         unique() %>%
         sort() %>%
         paste()


### PR DESCRIPTION
Permanently filter out 211_USGS discharges, which were only done to compare flow meter values with USGS gaging site and aren't needed for any existing or future rating curve. This removes "211_USGS" from the dropdown of site choices on the Quabbin Ratings tab.